### PR TITLE
Improve pre-requisites documentation

### DIFF
--- a/docs/pre-requisites.md
+++ b/docs/pre-requisites.md
@@ -46,6 +46,20 @@ If you have not done so already, you should enable the APIs for the following se
     <img src="img/../../img/enabling-api-console.png">
 </p>
 
+Or if you prefer to use the command line, these can be enabled with `gcloud`:
+
+```sh
+MY_PROJECT="my-moodle-project"
+gcloud config set $MY_PROJECT
+
+gcloud services enable \
+    cloudbuild.googleapis.com \
+    compute.googleapis.com \
+    artifactregistry.googleapis.com \
+    sql-component.googleapis.com \
+    sqladmin.googleapis.com
+```
+
 ## Get a project set up and administrative rights for it
 
 One of the tools available in Google Cloud to structure and organize projects in the cloud is "Projects". 

--- a/docs/pre-requisites.md
+++ b/docs/pre-requisites.md
@@ -33,7 +33,7 @@ If you have not done so already, you should enable the APIs for the following se
 
    * Google Kubernetes Service
    * Artifact Registry
-   * Cloud Firestore
+   * Cloud Filestore
    * Cloud SQL
    * Virtual Private Connect (VPC)
    * Cloud CDN
@@ -57,7 +57,8 @@ gcloud services enable \
     compute.googleapis.com \
     artifactregistry.googleapis.com \
     sql-component.googleapis.com \
-    sqladmin.googleapis.com
+    sqladmin.googleapis.com \
+    file.googleapis.com
 ```
 
 ## Get a project set up and administrative rights for it

--- a/docs/pre-requisites.md
+++ b/docs/pre-requisites.md
@@ -58,7 +58,8 @@ gcloud services enable \
     artifactregistry.googleapis.com \
     sql-component.googleapis.com \
     sqladmin.googleapis.com \
-    file.googleapis.com
+    file.googleapis.com \
+    recaptchaenterprise.googleapis.com
 ```
 
 ## Get a project set up and administrative rights for it

--- a/docs/pre-requisites.md
+++ b/docs/pre-requisites.md
@@ -12,6 +12,34 @@ If you company already has a account with Google Cloud, please talk to your admi
 
 If you're new to Google Cloud and would like to spin up Modern Moodle as your first workload in the cloud or learning how to operate Google Cloud, please refer to [this link](https://cloud.google.com/free) to get a free account.
 
+## Get a project set up and administrative rights for it
+
+One of the tools available in Google Cloud to structure and organize projects in the cloud is "Projects". 
+
+Projects allow not only to logically group workloads (clusters, databases, virtual machines, and so on) together, but also to define specific permissions to a user, application or group of users.
+
+So, before getting hands down with the deployment:
+
+1. Get your user account in Google Cloud with "Project Creator" rights through Identity Access Manager (IAM) mechanism, as depicted below. If you're deploying it in an enterprise account with cloud administrators in place, you might need to request access to them to get it done.
+
+<p align="center">
+    <img src="img/../../img/iam-user-account.png">
+</p>
+
+2. Permission granted, create a new project in Google Cloud by following the steps described in [this tutorial](https://cloud.google.com/resource-manager/docs/creating-managing-projects).
+
+<p align="center">
+    <img src="img/../../img/new-project-google-console.png">
+</p>
+
+3. Get the administrative previously settled account (step 1) and define it as owner with the project (step 2), as depicted below.
+
+<p align="center">
+    <img src="img/../../img/iam-account-owner-project.png">
+</p>
+
+> Important to mention that we suggest overcoming these initial steps through web console just for the sake of simplicity but it could be easily had happen by leveraging other approaches like `gcloud` command line, and others.
+
 ## Enable Moodle's underlying infrastructure services APIs in Google Cloud
 
 You might inquire in the case of an administrative API of a given cloud service used by Modern Moodle's infrastructure is not enabled for usage by default. 
@@ -61,34 +89,6 @@ gcloud services enable \
     file.googleapis.com \
     recaptchaenterprise.googleapis.com
 ```
-
-## Get a project set up and administrative rights for it
-
-One of the tools available in Google Cloud to structure and organize projects in the cloud is "Projects". 
-
-Projects allow not only to logically group workloads (clusters, databases, virtual machines, and so on) together, but also to define specific permissions to a user, application or group of users.
-
-So, before getting hands down with the deployment:
-
-1. Get your user account in Google Cloud with "Project Creator" rights through Identity Access Manager (IAM) mechanism, as depicted below. If you're deploying it in an enterprise account with cloud administrators in place, you might need to request access to them to get it done.
-
-<p align="center">
-    <img src="img/../../img/iam-user-account.png">
-</p>
-   
-2. Permission granted, create a new project in Google Cloud by following the steps described in [this tutorial](https://cloud.google.com/resource-manager/docs/creating-managing-projects).
-
-<p align="center">
-    <img src="img/../../img/new-project-google-console.png">
-</p>
-
-3. Get the administrative previously settled account (step 1) and define it as owner with the project (step 2), as depicted below.
-
-<p align="center">
-    <img src="img/../../img/iam-account-owner-project.png">
-</p>
-
-> Important to mention that we suggest overcoming these initial steps through web console just for the sake of simplicity but it could be easily had happen by leveraging other approaches like `gcloud` command line, and others.
 
 ## Install `gcloud` command line extension
 


### PR DESCRIPTION
Hello, I am starting to set up the environment and will be contributing updates as I go along. I signed the CLA as noted in the contributing guidelines, let me know if there is a template for PRs or naming conventions to follow!

For this I added the gcloud command for enabling the required APIs, fixed some typos, and changed the order of the documentation. They have users enable services first, then create the project; I believe it should be the other way around so the services are enabled in the new project.

Thank you for putting all this together, I am looking forward to contributing more in the future!