### PR TITLE
set PHP_MAX_INPUT_VARS to 6k in non-helm deployment

### DIFF
--- a/5a-deployment-no-helm-this-is-optional/moodle-deployment.yaml
+++ b/5a-deployment-no-helm-this-is-optional/moodle-deployment.yaml
@@ -81,7 +81,7 @@ spec:
         - name: PHP_MAX_EXECUTION_TIME
           value: "1200"
         - name: PHP_MAX_INPUT_VARS
-          value: "800"
+          value: "6000"
         - name: MOODLE_DATABASE_TYPE
           value: mysqli
         image: <YOUR-REPOSITORY>/<YOUR-IMAGE-TAG>


### PR DESCRIPTION
Moodle >=4 will show a warning if PHP's `max_input_vars` setting is this low, they recommend at least 5000 and the value is set to 6000 in two other places in this repo. I'm assuming there is no special reason to have it lower for the non-helm deployment.