### PR TITLE
Adjusting php81-fpm tuning setings for 1Gi Ram and 250 milicores

### DIFF
--- a/4-moodle-image-builder/base/etc/php81/php-fpm.conf
+++ b/4-moodle-image-builder/base/etc/php81/php-fpm.conf
@@ -102,7 +102,7 @@ process_control_timeout = 10s
 ; Note: A value of 0 indicates no limit
 ; Default Value: 0
 ; process.max = 128
-process.max = 1
+process.max = 0
 
 ; Specify the nice(2) priority to apply to the master process (only if set)
 ; The value can vary from -19 (highest priority) to 20 (lowest priority)

--- a/4-moodle-image-builder/base/etc/php81/php-fpm.d/moodle.conf
+++ b/4-moodle-image-builder/base/etc/php81/php-fpm.d/moodle.conf
@@ -28,10 +28,10 @@ php_admin_flag[allow_url_fopen] = off
 
 ; Process Manager
 pm = static
-pm.max_children = 2
+pm.max_children = 3
 pm.start_servers = 4
-pm.min_spare_servers = 2
-pm.max_spare_servers = 4
+pm.min_spare_servers = 4
+pm.max_spare_servers = 8
 pm.process_idle_timeout = 15s
 pm.max_requests = 256
 


### PR DESCRIPTION
Fixing FPM adjustments to be able to run benchmark tests and get the most of the setup using 1Gi ram and 250 milicores.