### PR TITLE
Update moodle-hpa.yaml - autoscaling API

### DIFF
--- a/9-hpa/moodle-hpa.yaml
+++ b/9-hpa/moodle-hpa.yaml
@@ -11,7 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: moodle-hpa


### PR DESCRIPTION
It seems that the autoscaling/v2beta2 API version of HorizontalPodAutoscaler has been deprecated.

See https://kubernetes.io/docs/reference/using-api/deprecation-guide/#horizontalpodautoscaler-v126