### PR TITLE
🔒 Fix hardcoded MySQL root password vulnerability

### DIFF
--- a/0-infra/envs.sh
+++ b/0-infra/envs.sh
@@ -49,9 +49,10 @@ NAT_ROUTER=<YOUR-NAT-CONFIG-ROUTER>
 # db specific variables
 GKE_NAME=<YOUR-GKE-CLUSTER-NAME>
 MYSQL_INSTANCE_NAME=<YOUR-MYSQL-INSTANCE-NAME>
-MYSQL_ROOT_PASSWORD=<YOUR-MYSQL-INSTANCE-PASSWORD>
+# MYSQL_ROOT_PASSWORD is not set here to avoid hardcoding secrets.
+# It will be prompted for during infra-creation.sh if not already set.
 MYSQL_DB=<YOUR-MOODLE-DB-NAME>
-MYSQL_MOODLE_DB_CHARSET=utf8mb4 #recommended collation for Moodle. Change only if necessary.
+MYSQL_MOODLE_DB_CHARSET=utf8mb4 #recommended charset for Moodle. Change only if necessary.
 MYSQL_MOODLE_DB_COLLATION=utf8mb4_unicode_ci #recommended collation for Moodle. Change only if necessary.
 
 # other managed services variables

--- a/0-infra/infra-creation.sh
+++ b/0-infra/infra-creation.sh
@@ -19,6 +19,12 @@ set -ex
 # load env vars file
 source ./envs.sh
 
+# prompt for mysql root password if not set
+if [ -z "${MYSQL_ROOT_PASSWORD}" ]; then
+  read -sp "Enter MySQL root password: " MYSQL_ROOT_PASSWORD
+  echo
+fi
+
 # sets up the default project where this infra will be deployed into
 gcloud config set project $PROJECT_ID
 
@@ -153,6 +159,7 @@ gcloud services vpc-peerings connect \
 gcloud services vpc-peerings list --network=$VPC_NAME
 
 # creates cloud sql instance (managed)
+{ set +x; } 2>/dev/null
 gcloud sql instances create $MYSQL_INSTANCE_NAME \
   --database-version=MYSQL_8_0 \
   --cpu 1 \
@@ -172,7 +179,8 @@ gcloud sql instances create $MYSQL_INSTANCE_NAME \
   --retained-backups-count=7 \
   --backup-start-time=03:00 \
   --database-flags=character_set_server=utf8,default_time_zone=-03:00 \
-  --root-password=$MYSQL_ROOT_PASSWORD
+  --root-password="$MYSQL_ROOT_PASSWORD"
+set -x
 
 # list cloud sql instances created
 gcloud sql instances list

--- a/docs/deploying-infrastructure.md
+++ b/docs/deploying-infrastructure.md
@@ -178,9 +178,10 @@ gcloud services vpc-peerings connect \
   --network=$VPC_NAME
 ```
 
-13. Creates a Cloud SQL instance (managed).
+13. Creates a Cloud SQL instance (managed). The command is wrapped in `set +x` to ensure the password is not logged.
 
 ```
+{ set +x; } 2>/dev/null
 gcloud sql instances create $MYSQL_INSTANCE_NAME \
   --database-version=MYSQL_8_0 \
   --cpu 1 \
@@ -201,6 +202,7 @@ gcloud sql instances create $MYSQL_INSTANCE_NAME \
   --backup-start-time=03:00 \
   --database-flags=character_set_server=utf8,default_time_zone=-03:00 \
   --root-password=$MYSQL_ROOT_PASSWORD
+set -x
 ```
 
 14. Creates Moodle's database with proper charset.

--- a/docs/file-env-sh.md
+++ b/docs/file-env-sh.md
@@ -27,7 +27,7 @@ The following table outlines all the variables that need to be filled in.
 | NAT_ROUTER | Names Nat Router service.  |
 | GKE_NAME | Names Google Kubernetes Engine (GKE) cluster that will host Moodle's web application. |
 | MYSQL_INSTANCE_NAME | Names MySQL instance out of Cloud SQL. |
-| MYSQL_ROOT_PASSWORD | Plain text that settles database's password. |
+| MYSQL_ROOT_PASSWORD | Optional. Plain text that settles database's password. If not provided, it will be prompted for during infrastructure creation. |
 | MYSQL_DB | Names Moodle's MySQL database. |
 | MYSQL_MOODLE_DB_CHARSET | Recommended charset for Moodle. Change only if necessary and you're absolutely sure of it. |
 | MYSQL_MOODLE_DB_COLLATION | Recommended collation for Moodle. Change only if necessary and you're absolutely sure of it. |


### PR DESCRIPTION
- Removed the hardcoded MYSQL_ROOT_PASSWORD template from 0-infra/envs.sh.
- Added logic to 0-infra/infra-creation.sh to prompt for the password if not set.
- Wrapped sensitive gcloud commands with set +x/set -x to prevent password leakage in logs.
- Updated documentation to reflect these security improvements.