### PR TITLE
🔒 [security fix] Remove hardcoded generic SMTP credentials from samples and templates

### DIFF
--- a/5a-deployment-no-helm/deployment-templates/moodle-configmap-nginx-template.yaml
+++ b/5a-deployment-no-helm/deployment-templates/moodle-configmap-nginx-template.yaml
@@ -53,8 +53,8 @@ data:
   NOEMAIL_EVER: 'true' # blocks moodle from sending e-mails
   SMTP_HOST: 'some.smtp.com'
   SMTP_PORT: '587'
-  SMTP_USER: 'your_email@yourserver.com'
-  SMTP_PASSWORD: 'your_password'
+  SMTP_USER: '<REPLACE_WITH_YOUR_SMTP_USER>'
+  SMTP_PASSWORD: '<REPLACE_WITH_YOUR_SMTP_PASSWORD>'
   SMTP_PROTOCOL: 'tls'
   MOODLE_MAIL_NOREPLY_ADDRESS: 'noreply@localhost'
   MOODLE_MAIL_PREFIX: '[moodle]'

--- a/5a-deployment-no-helm/moodle-configmap-nginx-sample.yaml
+++ b/5a-deployment-no-helm/moodle-configmap-nginx-sample.yaml
@@ -53,8 +53,8 @@ data:
   NOEMAIL_EVER: 'true' # blocks moodle from sending e-mails
   SMTP_HOST: 'some.smtp.com'
   SMTP_PORT: '587'
-  SMTP_USER: 'your_email@yourserver.com'
-  SMTP_PASSWORD: 'your_password'
+  SMTP_USER: '<REPLACE_WITH_YOUR_SMTP_USER>'
+  SMTP_PASSWORD: '<REPLACE_WITH_YOUR_SMTP_PASSWORD>'
   SMTP_PROTOCOL: 'tls'
   MOODLE_MAIL_NOREPLY_ADDRESS: 'noreply@localhost'
   MOODLE_MAIL_PREFIX: '[moodle]'


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
Hardcoded generic SMTP credentials ('your_password' and 'your_email@yourserver.com') in sample and template YAML configuration files.

⚠️ **Risk:** The potential impact if left unfixed
Generic default credentials in configuration files can be accidentally deployed to production environments, leading to insecure configurations or broken functionality if the user assumes they are just placeholders and doesn't change them. Using explicit placeholders like `<REPLACE_WITH_YOUR_...>` forces the user to provide valid configuration values.

🛡️ **Solution:** How the fix addresses the vulnerability
Replaced the generic values with explicit, attention-grabbing placeholders:
- `SMTP_PASSWORD: 'your_password'` -> `SMTP_PASSWORD: '<REPLACE_WITH_YOUR_SMTP_PASSWORD>'`
- `SMTP_USER: 'your_email@yourserver.com'` -> `SMTP_USER: '<REPLACE_WITH_YOUR_SMTP_USER>'`

This change was applied to:
- `5a-deployment-no-helm/moodle-configmap-nginx-sample.yaml`
- `5a-deployment-no-helm/deployment-templates/moodle-configmap-nginx-template.yaml`

---
*PR created automatically by Jules for task [15991544156581184287](https://jules.google.com/task/15991544156581184287) started by @ernani*