### PR TITLE
mount paths should correspond to MOODLE_ROOT_PATH, MOODLE_DATAROOT_PATH

### DIFF
--- a/5a-deployment-no-helm/moodle-deployment-nginx.yaml
+++ b/5a-deployment-no-helm/moodle-deployment-nginx.yaml
@@ -289,11 +289,11 @@ spec:
             memory: 1Gi
         volumeMounts:
         - name: moodleroot-vol
-          mountPath: /moodleroot/moodle
-          subPath: moodleroot/moodle
+          mountPath: /moodleroot-instance1/moodle
+          subPath: moodleroot-instance1/moodle
         - name: moodleroot-vol
-          mountPath: /moodleroot/moodledata
-          subPath: moodleroot/moodledata
+          mountPath: /moodleroot-instance1/moodledata
+          subPath: moodleroot-instance1/moodledata
         - name: moodleroot-vol
           mountPath: /etc/nginx
           subPath: etc/nginx


### PR DESCRIPTION
Mount paths defined in this file should corrisponde to the paths of MOODLE_ROOT_PATH, MOODLE_DATAROOT_PATH, defined in 'moodle-configmap-nginx.yaml'. If not, Moodle would be installed locally on each node, rather than on the NFS.