### PR TITLE
Scale target ref name

### DIFF
--- a/9-hpa/moodle-hpa.yaml
+++ b/9-hpa/moodle-hpa.yaml
@@ -22,7 +22,7 @@ spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: moodle
+    name: moodle-deployment
   metrics:
   - type: Resource
     resource:


### PR DESCRIPTION
A question, kindly:
Shouldn't the scale target ref name correspond to the Deployment name in: 5a-deployment-no-helm/moodle-deployment-nginx.yaml